### PR TITLE
Maybe it works now?

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,37 +1,40 @@
 module Main (main) where
 
 import Distribution.System ( buildOS, OS(..) )
-import Distribution.Simple.InstallDirs ( libdir, bindir )
+import Distribution.Simple.InstallDirs ( libdir )
 import Distribution.Simple.Setup ( ConfigFlags, fromFlag, configVerbosity
                                  , InstallFlags, defaultCopyFlags
                                  , installDistPref, CleanFlags
                                  , toFlag, CopyDest(NoCopyDest)
                                  , installVerbosity, cleanVerbosity
-                                 , CopyFlags(..) )
-import Distribution.Simple.Utils ( rawSystemExit, installOrdinaryFile
-                                 , installExecutableFile, copyFileVerbose
-                                 , createDirectoryIfMissingVerbose )
+                                 , CopyFlags(..)
+                                 , configProgramArgs )
+import Distribution.Simple.Utils ( rawSystemExit, installOrdinaryFile )
 import Distribution.Verbosity ( verbose )
 import Distribution.Simple ( defaultMainWithHooks
                            , simpleUserHooks
-                           , buildHook, Args
+                           , buildHook, Args, confHook
                            , UserHooks(preConf, preClean,
                                        postCopy, postInst) )
 import Distribution.Simple.LocalBuildInfo ( absoluteInstallDirs
-                                          , LocalBuildInfo )
+                                          , LocalBuildInfo(..) )
 import Distribution.PackageDescription ( emptyBuildInfo
                                        , updatePackageDescription
-                                       , HookedBuildInfo(..)
+                                       , HookedBuildInfo
                                        , BuildInfo(..)
                                        , PackageDescription )
-import System.Cmd ( system )
 import System.FilePath ( (</>) )
 
+extraLibDir :: FilePath
 extraLibDir = "build"
 
 main :: IO ()
 main = defaultMainWithHooks simpleUserHooks
   { preConf   = \a f -> makeGlfw a f >> preConf simpleUserHooks a f
+  , confHook  = \a cfs -> do
+      let pkgForce = [("ghc-pkg",["--force"]) | buildOS == OSX ]
+          cfs' = cfs { configProgramArgs = configProgramArgs cfs ++ pkgForce }
+      confHook simpleUserHooks a cfs'
   , preClean  = \a f -> makeClean a f >> preClean simpleUserHooks a f
   , buildHook = \pkgDesc lbi h f ->
       buildHook simpleUserHooks (glfwPkgDesc pkgDesc) lbi h f
@@ -60,6 +63,7 @@ makeClean _ flags = do
       make
     _ -> return ()
 
+glfwPkgDesc :: PackageDescription -> PackageDescription
 glfwPkgDesc pkgDesc =
   case buildOS of
     OSX -> updatePackageDescription libDirGlfw pkgDesc
@@ -90,13 +94,12 @@ postCopyGlfw _ flags pkgDesc lbi =
       let installDirs = absoluteInstallDirs pkgDesc lbi
             . fromFlag . copyDest $ flags
           libPref = libdir installDirs
-          binPref = bindir installDirs
           verbosity = fromFlag $ copyVerbosity flags
-          outDir = libPref
           copy dest f = installOrdinaryFile verbosity (extraLibDir</>f) (dest</>f)
       maybe (return ()) (copy libPref) (Just libName)
       maybe (return ()) (copy libPref) (Just sharedName)
     _ -> return ()
 
+libName, sharedName :: FilePath
 libName = "libglfw.a"
 sharedName = "libglfw.dylib"


### PR DESCRIPTION
I upgraded from ghc 7 to 7.0.2 on my mac and the build stopped working.  I traced it down to a problem with ghc-pkg.  We use a relative path extra-lib-dirs and some versions ghc-pkg was not okay with that.

So, here is what I did:
- programmatically add `--force` to ghc-pkg during the configure step
- did a full retest on windows/osx and with GLFW-b-demo.

I think this use of `--force` is safe, albeit ugly.  I really don't know how else we can handle this.  One thing I haven't tried that may work (but I'm not sure) is to take the makefile and the source bits, pull them out into an OSX package, use build-type: Make, for that package and make it an os-specific build dependency.  But, if you're okay with the `--force
