### PR TITLE
Bug reported via reddit

### DIFF
--- a/src/Graphics/UI/GLFW.hsc
+++ b/src/Graphics/UI/GLFW.hsc
@@ -116,7 +116,7 @@ foreign import ccall unsafe glfwGetVersion               :: Ptr CInt -> Ptr CInt
 
 foreign import ccall unsafe glfwOpenWindow               :: CInt -> CInt -> CInt -> CInt -> CInt -> CInt -> CInt -> CInt -> CInt -> IO CInt
 foreign import ccall unsafe glfwOpenWindowHint           :: CInt -> CInt -> IO ()
-foreign import ccall unsafe glfwCloseWindow              :: IO ()
+foreign import ccall        glfwCloseWindow              :: IO ()
 foreign import ccall        glfwSetWindowCloseCallback   :: FunPtr GlfwWindowCloseCallback -> IO ()
 foreign import ccall unsafe glfwSetWindowTitle           :: CString -> IO ()
 foreign import ccall unsafe glfwSetWindowSize            :: CInt -> CInt -> IO ()


### PR DESCRIPTION
Brian,

Someone on reddit reported a crash.  If you read the comments you will see their program:
http://www.reddit.com/r/haskell/comments/g6a06/comparison_picking_a_gui_library_to_use_with/c1la0uf

I tried it here and it crashed.  So I removed the 'unsafe' from the FFI import of glfwCloseWindow and the crash went away.  I think there is a good chance that nothing in that module should be unsafe.  Very little of it should benefit from being unsafe, which is typically only there for performance reasons.  My motto is, when in doubt mark things safe :)

Anyway, this pull request is for the minimum change to make the program in that reddit thread work.  If you want to test things on your end, here is the cabal file I used to build it:

```
Name:                glfw-test
Version:             0.1
License:             BSD3
License-file:        LICENSE
Category:            Graphics
Build-type:          Simple
Cabal-version:       >=1.2
Executable glfw-test
  Main-is:             Main.hs  
  Build-depends:       base < 5,
                       GLFW-b == 0.0.2.3,
                       vect == 0.4.6,
                       vect-opengl == 0.4.6,
                       OpenGL == 2.4.0.1
```

I'll leave it up to you to decide if you want to mark more things as 'safe' before the next release.

Thanks,
Jason
