### PR TITLE
add NOINLINEs

### DIFF
--- a/src/Graphics/UI/GLFW.hsc
+++ b/src/Graphics/UI/GLFW.hsc
@@ -975,13 +975,21 @@ windowRefreshCallback :: IORef (Maybe (FunPtr GlfwWindowRefreshCallback))
 windowSizeCallback    :: IORef (Maybe (FunPtr GlfwWindowSizeCallback))
 
 charCallback          = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE charCallback #-}
 keyCallback           = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE keyCallback #-}
 mouseButtonCallback   = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE mouseButtonCallback #-}
 mousePositionCallback = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE mousePositionCallback #-}
 mouseWheelCallback    = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE mouseWheelCallback #-}
 windowCloseCallback   = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE windowCloseCallback #-}
 windowRefreshCallback = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE windowRefreshCallback #-}
 windowSizeCallback    = unsafePerformIO (newIORef Nothing)
+{-# NOINLINE windowSizeCallback #-}
 
 storeCallback :: IORef (Maybe (FunPtr a)) -> FunPtr a -> IO ()
 storeCallback ior cb =


### PR DESCRIPTION
Brian,

Usually when you have toplevel uses of unsafePerformIO to create IORef you need to mark them as "NOINLINE".  Otherwise when GHC inlines them the 'unsafePerformIO' will actually happen multiple times.

I haven't noticed any bugs due to this, but I added them anyway as it probably just a matter of time till someone uses them in a way that creates multiple IORefs.

Please let me know if you have any questions.

Thanks,
Jason
