### PR TITLE
Fix for issue#8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+GCCFLAGS  := $(shell ghc --info | ghc -e "fmap read getContents >>= putStrLn . unwords . read . Data.Maybe.fromJust . lookup \"Gcc Linker flags\"")
 FRAMEWORK := -framework AGL -framework Cocoa -framework OpenGL
-GLFW_FLAG := -m32 -O2 -Iglfw/include -Iglfw/lib -Iglfw/lib/cocoa $(CFLAGS)
+GLFW_FLAG := $(GCCFLAGS) -msse2 -O2 -Iglfw/include -Iglfw/lib -Iglfw/lib/cocoa $(CFLAGS)
 SRC_DIR   := glfw/lib/cocoa
 GLFW_DIR  := glfw/lib
 BUILD_DIR := build


### PR DESCRIPTION
I figured out how to detect the GCC linker flags thanks to stackoverflow: http://stackoverflow.com/questions/6217406/how-can-i-detect-if-ghc-is-set-to-generate-32bit-or-64bit-code-by-default

I tested this on a 32bit mac and a 64bit mac.  Shouldn't affect non-mac users.

Thanks!
Jason
