### PR TITLE
Add support for loading in GHCI on OSX

### DIFF
--- a/GLFW-b.cabal
+++ b/GLFW-b.cabal
@@ -111,7 +111,7 @@ library
   else
     if os(darwin)
       extra-libraries: glfw
-      extra-lib-dirs: build/dynamic
+      extra-lib-dirs: build
     else
       if os(mingw32)
         include-dirs:

--- a/Makefile
+++ b/Makefile
@@ -13,22 +13,17 @@ C_SRC     := $(wildcard $(SRC_DIR)/*.c)
 GLFW_SRC  := $(wildcard $(GLFW_DIR)/*.c)
 OBJS      := $(addprefix $(BUILD_DIR)/, $(OBJ_C_SRC:.m=.o) $(C_SRC:.c=.o))
 
-all: $(BUILD_DIR)/static/libglfw.a $(BUILD_DIR)/dynamic/libglfw.dylib
+all: $(BUILD_DIR)/libglfw.dylib
 
-$(BUILD_DIR)/dynamic/libglfw.dylib: $(OBJS)
+$(BUILD_DIR)/libglfw.dylib: $(OBJS)
 	$(CC) -dynamiclib -Wl,-single_module -compatibility_version 1       \
         -current_version 1                                            \
         $(GLFW_FLAG) -o $@ $(OBJS) $(GLFW_SRC) $(FRAMEWORK)
-
-$(BUILD_DIR)/static/libglfw.a: $(OBJS)
-	ar -rcs $@ $(OBJS)
 
 .PHONY: $(BUILD_DIR)/$(SRC_DIR)/.build-tag
 
 $(BUILD_DIR)/$(SRC_DIR)/.build-tag:
 	mkdir -p $(BUILD_DIR)/$(SRC_DIR)
-	mkdir -p $(BUILD_DIR)/static
-	mkdir -p $(BUILD_DIR)/dynamic
 	touch $@
 
 $(OBJS): $(BUILD_DIR)/$(SRC_DIR)/.build-tag


### PR DESCRIPTION
These changes should close issue #5.

The changes are documented here: http://stackoverflow.com/questions/6323755/osx-ghci-dylib-what-is-the-correct-way

I've only tested it on OSX at the moment.  I do expect it to continue to behave the same on other platforms, but I didn't test it.  I did the fix in such a way that there is no dependency on linker features that were added in 10.4 and 10.5.  We could do it in a more general way by assuming OSX 10.5, but I'd rather not break backwards compatibility if it can be avoided.

You'll need to bump the version in the cabal file before doing an upload.  Please let me know if you have any questions!

Thanks,
Jason
