### PR TITLE
Interface to enable/disable the mouse cursor.

### DIFF
--- a/GLFW-b.cabal
+++ b/GLFW-b.cabal
@@ -1,5 +1,5 @@
 name:         GLFW-b
-version:      0.1.0.0
+version:      0.1.0.1
 
 category:     Graphics
 

--- a/src/Graphics/UI/GLFW.hsc
+++ b/src/Graphics/UI/GLFW.hsc
@@ -73,6 +73,8 @@ module Graphics.UI.GLFW
   , setMouseButtonCallback
   , setMousePositionCallback
   , setMouseWheelCallback
+  , enableMouseCursor
+  , disableMouseCursor
     --
   , MouseButton(..)
   , MouseButtonCallback
@@ -162,6 +164,9 @@ foreign import ccall glfwSetTime                  :: CDouble -> IO ()
 foreign import ccall glfwSleep                    :: CDouble -> IO ()
 
 foreign import ccall glfwGetGLVersion             :: Ptr CInt -> Ptr CInt -> Ptr CInt -> IO ()
+
+foreign import ccall glfwEnable                   :: CInt -> IO ()
+foreign import ccall glfwDisable                  :: CInt -> IO ()
 
 type GlfwCharCallback          = CInt -> CInt -> IO ()
 type GlfwKeyCallback           = CInt -> CInt -> IO ()
@@ -824,6 +829,14 @@ setMouseWheelCallback cb = do
     ccb <- wrapMouseWheelCallback (cb . fromC)
     glfwSetMouseWheelCallback ccb
     storeCallback mouseWheelCallback ccb
+
+-- |Make the mouse cursor visible.
+enableMouseCursor :: IO ()
+enableMouseCursor = glfwEnable (#const GLFW_MOUSE_CURSOR)
+
+-- |Make the mouse cursor invisible.
+disableMouseCursor :: IO ()
+disableMouseCursor = glfwDisable (#const GLFW_MOUSE_CURSOR)
 
 -- -- -- -- -- -- -- -- -- --
 


### PR DESCRIPTION
GLFW makes the cursor invisible in fullscreen mode by default. For compatibility with the GLUT backend of the gloss library, we need to explicitly re-enable the mouse cursor, which also makes the getMousePosition call compatible with windowed mode.
