### PR TITLE
fix: ignore .ghci configuration in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-GCCFLAGS  := $(shell ghc --info | ghc -e "fmap read getContents >>=   \
-             putStrLn . unwords . read . Data.Maybe.fromJust . lookup \
+GHC	  := ghc -ignore-dot-ghci
+GCCFLAGS  := $(shell $(GHC) --info | $(GHC) -e "fmap read getContents >>= \
+             putStrLn . unwords . read . Data.Maybe.fromJust . lookup     \
              \"Gcc Linker flags\"")
 FRAMEWORK := -framework Cocoa -framework OpenGL
 GLFW_FLAG := $(GCCFLAGS) -O2 -msse2 -fno-common -Iglfw/include -Iglfw/lib    \


### PR DESCRIPTION
ghci options such as +s and +t add extra characters to the end of the output. This becomes part of GCCFLAGS and sh fails when trying to evaluate it.
