### PR TITLE
enableKeyRepeat/disableKeyRepeat

### DIFF
--- a/src/Graphics/UI/GLFW.hsc
+++ b/src/Graphics/UI/GLFW.hsc
@@ -57,6 +57,8 @@ module Graphics.UI.GLFW
   , pollEvents
   , waitEvents
   , enableAutoPoll
+  , enableKeyRepeat
+  , disableKeyRepeat 
   , disableAutoPoll
     -- **  Keyboard
   , keyIsPressed
@@ -565,6 +567,11 @@ enableAutoPoll = glfwEnable (#const GLFW_AUTO_POLL_EVENTS)
 disableAutoPoll :: IO ()
 disableAutoPoll = glfwDisable (#const GLFW_AUTO_POLL_EVENTS)
 
+enableKeyRepeat :: IO ()
+enableKeyRepeat = glfwEnable (#const GLFW_KEY_REPEAT)
+
+disableKeyRepeat :: IO ()
+disableKeyRepeat = glfwDisable (#const GLFW_KEY_REPEAT)
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- Keyboard
 


### PR DESCRIPTION
Added two functions to enable/disable key repeat. Without these using char callbacks for text input was very difficult. It also obeys system-wide settings (at least on windows) for repeat delay and repeat rate.
