### PR TITLE
Fix the build for GHC 7.4.1

### DIFF
--- a/GLFW-b.cabal
+++ b/GLFW-b.cabal
@@ -56,10 +56,9 @@ library
   build-depends:
     base              < 5,
     bindings-GLFW    == 0.0.*,
-    template-haskell == 2.8.*,
     th-lift          == 0.5.*
 
-  if impl(ghc == 7.4.1)
+  if impl(ghc < 7.6)
     build-depends:
       template-haskell == 2.7.*
   else
@@ -87,7 +86,7 @@ test-suite main
     test-framework-hunit == 0.3.*,
     th-lift              == 0.5.*
 
-  if impl(ghc == 7.4.1)
+  if impl(ghc < 7.6)
     build-depends:
       template-haskell == 2.7.*
   else

--- a/Graphics/UI/GLFW.hs
+++ b/Graphics/UI/GLFW.hs
@@ -137,16 +137,16 @@ module Graphics.UI.GLFW
 import Prelude hiding (init)
 
 import Control.Monad         (when)
-import Data.IORef            (IORef, atomicModifyIORef', newIORef)
+import Data.IORef            (IORef, atomicModifyIORef, newIORef)
 import Foreign.C.String      (peekCString, withCString)
 import Foreign.C.Types       (CUInt, CUShort)
 import Foreign.Marshal.Alloc (alloca)
 import Foreign.Marshal.Array (advancePtr, allocaArray, peekArray, withArray)
 import Foreign.Ptr           (FunPtr, freeHaskellFunPtr, nullFunPtr, nullPtr)
-import Foreign.Storable      (Storable(..))
+import Foreign.Storable      (Storable (..))
 import System.IO.Unsafe      (unsafePerformIO)
 
-import Graphics.UI.GLFW.Internal.C           (C(..))
+import Graphics.UI.GLFW.Internal.C           (C (..))
 import Graphics.UI.GLFW.Internal.Instances.C ()
 import Graphics.UI.GLFW.Types
 
@@ -227,7 +227,7 @@ setCallback wf af gf ior mcb = do
 storeCallback :: IORef (FunPtr a) -> FunPtr a -> IO ()
 storeCallback ior new = do
     -- Store the new FunPtr, retrieve the previous one.
-    prev <- atomicModifyIORef' ior (\cur -> (new, cur))
+    prev <- atomicModifyIORef ior (\cur -> (new, cur))
     -- Free the old FunPtr if necessary.
     when (prev /= nullFunPtr) $ freeHaskellFunPtr prev
 


### PR DESCRIPTION
There was a lingering dependency bug in the Cabal file and a use of atomicModifyIORef', which is not in older versions of base.
