### PR TITLE
Export postEmptyEvents

### DIFF
--- a/Graphics/UI/GLFW.hs
+++ b/Graphics/UI/GLFW.hs
@@ -81,6 +81,7 @@ module Graphics.UI.GLFW
   , setFramebufferSizeCallback, FramebufferSizeCallback
   , pollEvents
   , waitEvents
+  , postEmptyEvent
 
     -- * Input handling
   , Key                         (..)
@@ -746,6 +747,9 @@ pollEvents = c'glfwPollEvents >> executeScheduled
 
 waitEvents :: IO ()
 waitEvents = c'glfwWaitEvents >> executeScheduled
+
+postEmptyEvent :: IO ()
+postEmptyEvent = c'glfwPostEmptyEvent
 
 --------------------------------------------------------------------------------
 -- Input handling


### PR DESCRIPTION
After pulling https://github.com/bsl/bindings-GLFW/pull/34 this PR can provide the end-users of GLFW-b the ability to wake up threads stuck on `waitEvents`.