### PR TITLE
Upgrade 3.3

### DIFF
--- a/GLFW-b.cabal
+++ b/GLFW-b.cabal
@@ -1,5 +1,5 @@
 name:         GLFW-b
-version:      3.2.1.0
+version:      3.3.0.1
 category:     Graphics
 
 author:       Brian Lewis <brian@lorf.org>
@@ -16,14 +16,14 @@ description:
   library for creating windows with OpenGL contexts and managing input and
   events.
   .
-  GLFW-b depends on bindings-GLFW
+  This version of GLFW-b depends on git branch Upgrade-3.3 of bindings-GLFW
   (<http://hackage.haskell.org/package/bindings-GLFW>), which, as of the time
-  of this writing, binds to GLFW 3.2.1, released 2016-08-18
-  (<http://www.glfw.org/Version-3.2.1-released.html>
+  of this writing, binds to GLFW 3.3, not yet released
+  (<http://www.glfw.org/Version-3.3-released.html>
   <http://www.glfw.org/changelog.html>).
   .
   If you've used GLFW < 3 before, you should read the transition guide
-  (<http://www.glfw.org/docs/3.0/moving.html>).
+  (<http://www.glfw.org/docs/3.3/moving.html>).
 
 cabal-version: >= 1.10
 build-type:    Simple
@@ -74,7 +74,7 @@ test-suite main
   build-depends:
       base                 <  5
     , HUnit                >= 1.3 && < 1.7
-    , bindings-GLFW        >= 3.2.1.0
+    , bindings-GLFW        >= 3.3.0.1
     , deepseq              >= 1.1.0.0
     , test-framework       == 0.8.*
     , test-framework-hunit == 0.3.*

--- a/GLFW-b.cabal
+++ b/GLFW-b.cabal
@@ -1,5 +1,5 @@
 name:         GLFW-b
-version:      3.3.0.1
+version:      3.2.1.0
 category:     Graphics
 
 author:       Brian Lewis <brian@lorf.org>
@@ -16,14 +16,14 @@ description:
   library for creating windows with OpenGL contexts and managing input and
   events.
   .
-  This version of GLFW-b depends on git branch Upgrade-3.3 of bindings-GLFW
+  GLFW-b depends on bindings-GLFW
   (<http://hackage.haskell.org/package/bindings-GLFW>), which, as of the time
-  of this writing, binds to GLFW 3.3, not yet released
-  (<http://www.glfw.org/Version-3.3-released.html>
+  of this writing, binds to GLFW 3.2.1, released 2016-08-18
+  (<http://www.glfw.org/Version-3.2.1-released.html>
   <http://www.glfw.org/changelog.html>).
   .
   If you've used GLFW < 3 before, you should read the transition guide
-  (<http://www.glfw.org/docs/3.3/moving.html>).
+  (<http://www.glfw.org/docs/3.0/moving.html>).
 
 cabal-version: >= 1.10
 build-type:    Simple
@@ -74,7 +74,7 @@ test-suite main
   build-depends:
       base                 <  5
     , HUnit                >= 1.3 && < 1.7
-    , bindings-GLFW        >= 3.3.0.1
+    , bindings-GLFW        >= 3.2.1.0
     , deepseq              >= 1.1.0.0
     , test-framework       == 0.8.*
     , test-framework-hunit == 0.3.*

--- a/Graphics/UI/GLFW.hs
+++ b/Graphics/UI/GLFW.hs
@@ -204,9 +204,6 @@ module Graphics.UI.GLFW
   , getWaylandDisplay
   , getWaylandMonitor
   , getWaylandWindow
-  , getMirDisplay
-  , getMirMonitor
-  , getMirWindow
   , getEGLDisplay
   , getEGLContext
   , getEGLSurface
@@ -1639,18 +1636,6 @@ getWaylandMonitor = c'glfwGetWaylandMonitor . toC
 -- | See <http://www.glfw.org/docs/3.2/group__native.html#ga4738d7aca4191363519a9a641c3ab64c glfwGetWaylandWindow>
 getWaylandWindow :: Window -> IO (Ptr wl_surface)
 getWaylandWindow = c'glfwGetWaylandWindow . toC
-
--- | See <http://www.glfw.org/docs/3.2/group__native.html#ga40dd05325d9813fa67d61328c51d2930 glfwGetMirDisplay>
-getMirDisplay :: IO (Ptr mir_connection)
-getMirDisplay = c'glfwGetMirDisplay
-
--- | See <http://www.glfw.org/docs/3.2/group__native.html#gae0941c11dc8f01aeb7cbb563f5cd930b glfwGetMirMonitor>
-getMirMonitor :: Window -> IO Int
-getMirMonitor = (fmap fromC) . c'glfwGetMirMonitor . toC
-
--- | See <http://www.glfw.org/docs/3.2/group__native.html#ga964d52bb7932216c379762eef1ea9b05 glfwGetMirWindow>
-getMirWindow :: Window -> IO (Ptr mir_surface)
-getMirWindow = c'glfwGetMirWindow . toC
 
 -- | See <http://www.glfw.org/docs/3.2/group__native.html#ga1cd8d973f47aacb5532d368147cc3138 glfwGetEGLDisplay>
 getEGLDisplay :: IO (Ptr ())


### PR DESCRIPTION
Making this compatible with https://github.com/bsl/bindings-GLFW/pull/65 so it can compile. I suggest merging both at the same time, so the Upgrade-3.3 branches of both repos stay compatible. Not added new functions yet.