### PR TITLE
Publish Window and Monitor constructors

### DIFF
--- a/Graphics/UI/GLFW.hs
+++ b/Graphics/UI/GLFW.hs
@@ -37,7 +37,7 @@ module Graphics.UI.GLFW
   , rawMouseMotionSupported
 
     -- * Monitor handling
-  , Monitor
+  , Monitor      (..)
   , MonitorState (..)
   , VideoMode    (..)
   , GammaRamp    (gammaRampRed, gammaRampGreen, gammaRampBlue)
@@ -58,7 +58,7 @@ module Graphics.UI.GLFW
   , setGammaRamp
 
     -- * Window handling
-  , Window
+  , Window                 (..)
   , WindowHint             (..)
   , WindowAttrib           (..)
   , ContextRobustness      (..)


### PR DESCRIPTION
DearImgui callbacks require some pointer passing.
Unfortunately they're hidden behind newtypes.

https://github.com/haskell-game/dear-imgui.hs/issues/80
